### PR TITLE
Bump Golang to 1.10.3

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -81,7 +81,7 @@
       dest: ~/.tmux/plugins/tpm
 
   - name: download go
-    get_url: url=https://storage.googleapis.com/golang/go1.9.2.linux-amd64.tar.gz dest={{downloads_dir}}/go.tar.gz
+    get_url: url=https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz dest={{downloads_dir}}/go.tar.gz
 
   - name: extract go
     become: true


### PR DESCRIPTION
Bump Golang to 1.10.3 (currently latest)